### PR TITLE
Update Mpesa C2B Register Url into a stand alone doctype, that doesn'…

### DIFF
--- a/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.json
+++ b/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.json
@@ -1,128 +1,123 @@
 {
- "actions": [],
- "autoname": "field:mpesa_settings",
- "creation": "2021-11-10 03:59:38.274817",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "mpesa_settings",
-  "till_number",
-  "business_shortcode",
-  "column_break_4",
-  "company",
-  "mode_of_payment",
-  "register_status"
- ],
- "fields": [
-  {
-   "fieldname": "mpesa_settings",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Mpesa Settings",
-   "options": "Mpesa Settings",
-   "reqd": 1,
-   "unique": 1
-  },
-  {
-   "fetch_from": "mpesa_settings.till_number",
-   "fieldname": "till_number",
-   "fieldtype": "Data",
-   "label": "Till Number",
-   "read_only": 1
-  },
-  {
-   "fetch_from": "mpesa_settings.business_shortcode",
-   "fieldname": "business_shortcode",
-   "fieldtype": "Data",
-   "label": "Business Shortcode",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_4",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "mode_of_payment",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Mode of Payment",
-   "options": "Mode of Payment",
-   "reqd": 1
-  },
-  {
-   "default": "Pending",
-   "fieldname": "register_status",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Register Status",
-   "options": "Pending\nSuccess\nFailed",
-   "read_only": 1
-  },
-  {
-   "fieldname": "company",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Company",
-   "options": "Company",
-   "reqd": 1
-  }
- ],
- "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2021-11-18 05:08:03.509002",
- "modified_by": "Administrator",
- "module": "POSAwesome",
- "name": "Mpesa C2B Register URL",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts User",
-   "share": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Sales User",
-   "share": 1
-  }
- ],
- "sort_field": "modified",
- "sort_order": "DESC",
- "track_changes": 1
+    "actions": [],
+    "autoname": "field:business_shortcode",
+    "creation": "2021-11-10 03:59:38.274817",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+        "consumer_key",
+        "consumer_secret",
+        "business_shortcode",
+        "sandbox",
+        "column_break_4",
+        "company",
+        "register_status"
+    ],
+    "fields": [
+        {
+            "fieldname": "consumer_key",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Consumer Key",
+            "reqd": 1
+        },
+        {
+            "fieldname": "consumer_secret",
+            "fieldtype": "Password",
+            "in_list_view": 1,
+            "label": "Consumer Secret",
+            "reqd": 1
+        },
+        {
+            "fieldname": "business_shortcode",
+            "fieldtype": "Data",
+            "in_list_view": 1,
+            "label": "Business Shortcode",
+            "reqd": 1
+        },
+        {
+            "fieldname": "column_break_4",
+            "fieldtype": "Column Break"
+        },
+        {
+            "default": "0",
+            "fieldname": "sandbox",
+            "fieldtype": "Check",
+            "label": "Sandbox"
+        },
+        {
+            "default": "Pending",
+            "fieldname": "register_status",
+            "fieldtype": "Select",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Register Status",
+            "options": "Pending\nSuccess\nFailed",
+            "read_only": 1
+        },
+        {
+            "fieldname": "company",
+            "fieldtype": "Link",
+            "in_list_view": 1,
+            "in_standard_filter": 1,
+            "label": "Company",
+            "options": "Company",
+            "reqd": 1
+        }
+    ],
+    "index_web_pages_for_search": 1,
+    "links": [],
+    "modified": "2023-04-22 12:08:03.509002",
+    "modified_by": "Administrator",
+    "module": "POSAwesome",
+    "name": "Mpesa C2B Register URL",
+    "owner": "Administrator",
+    "permissions": [
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "System Manager",
+            "share": 1,
+            "write": 1
+        },
+        {
+            "create": 1,
+            "delete": 1,
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Accounts Manager",
+            "share": 1,
+            "write": 1
+        },
+        {
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Accounts User",
+            "share": 1
+        },
+        {
+            "email": 1,
+            "export": 1,
+            "print": 1,
+            "read": 1,
+            "report": 1,
+            "role": "Sales User",
+            "share": 1
+        }
+    ],
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "track_changes": 1
 }

--- a/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.py
+++ b/posawesome/posawesome/doctype/mpesa_c2b_register_url/mpesa_c2b_register_url.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2021, Youssef Restom and contributors
 # For license information, please see license.txt
 
-import frappe, requests
+import frappe
+import requests
 from frappe.model.document import Document
 from frappe.utils import get_request_site_address
 from posawesome.posawesome.api.m_pesa import get_token
@@ -11,28 +12,24 @@ class MpesaC2BRegisterURL(Document):
     def validate(self):
         sandbox_url = "https://sandbox.safaricom.co.ke"
         live_url = "https://api.safaricom.co.ke"
-        mpesa_settings = frappe.get_doc("Mpesa Settings", self.mpesa_settings)
-        env = "production" if not mpesa_settings.sandbox else "sandbox"
-        business_shortcode = (
-            mpesa_settings.business_shortcode
-            if env == "production"
-            else mpesa_settings.till_number
-        )
+        env = "production" if not self.sandbox else "sandbox"
+        business_shortcode = self.business_shortcode
+
         if env == "sandbox":
             base_url = sandbox_url
         else:
             base_url = live_url
         token = get_token(
-            app_key=mpesa_settings.consumer_key,
-            app_secret=mpesa_settings.get_password("consumer_secret"),
+            app_key=self.consumer_key,
+            app_secret=self.get_password("consumer_secret"),
             base_url=base_url,
         )
         site_url = get_request_site_address(True)
-        validation_url = (
-            site_url + "/api/method/posawesome.posawesome.api.m_pesa.validation"
-        )
         confirmation_url = (
             site_url + "/api/method/posawesome.posawesome.api.m_pesa.confirmation"
+        )
+        validation_url = (
+            site_url + "/api/method/posawesome.posawesome.api.m_pesa.validation"
         )
         register_url = base_url + "/mpesa/c2b/v2/registerurl"
 

--- a/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
+++ b/posawesome/posawesome/doctype/mpesa_payment_register/mpesa_payment_register.py
@@ -27,11 +27,10 @@ class MpesaPaymentRegister(Document):
                 "business_shortcode": self.businessshortcode,
                 "register_status": "Success",
             },
-            fields=["company", "mode_of_payment"],
+            fields=["company"],
         )
         if len(register_url_list) > 0:
             self.company = register_url_list[0].company
-            self.mode_of_payment = register_url_list[0].mode_of_payment
 
     def before_submit(self):
         if not self.transamount:

--- a/posawesome/public/js/posapp/components/pos/Mpesa-Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Mpesa-Payments.vue
@@ -126,7 +126,6 @@ export default {
         method: 'posawesome.posawesome.api.m_pesa.get_mpesa_draft_payments',
         args: {
           company: this.company,
-          mode_of_payment: this.mode_of_payment,
           mobile_no: this.mobile_no,
           full_name: this.full_name,
         },
@@ -170,7 +169,6 @@ export default {
       this.mobile_no = '';
       this.company = data.company;
       this.customer = data.customer;
-      this.mode_of_payment = data.mode_of_payment;
       this.dialog_data = '';
       this.selected = [];
     });

--- a/posawesome/public/js/posapp/components/pos/Payments.vue
+++ b/posawesome/public/js/posapp/components/pos/Payments.vue
@@ -820,7 +820,7 @@ export default {
         this.redeemed_customer_credit > this.invoice_doc.grand_total
       ) {
         evntBus.$emit('show_mesage', {
-          text: `can not redeam customer credit more than invoice total`,
+          text: `can not redeem customer credit more than invoice total`,
           color: 'error',
         });
         frappe.utils.play_sound('error');
@@ -1059,7 +1059,7 @@ export default {
       const vm = this;
       if (!this.invoice_doc.contact_mobile) {
         evntBus.$emit('show_mesage', {
-          text: __(`Pleas Set Customer Mobile Number`),
+          text: __(`Please Set Customer Mobile Number`),
           color: 'error',
         });
         evntBus.$emit('open_edit_customer');


### PR DESCRIPTION
- Update Mpesa C2B Register Url into a stand alone doctype, that doesn't depend on mpesa settings, or is connected to any mode of payment, because C2B registration is only once against a M-PESA pay bill or till number of the organization.
- Get_mpesa_mode_of_payments, from modes of payment table, not from Mpesa C2B Register Url as before
- Update Mpesa-Payments.Vue, i.e. remove mode of payments during fetching Mpesa Payments registering fetching Mpesa Payments register